### PR TITLE
docs: fix step1 shell words error

### DIFF
--- a/docs/en/guide/intro/get-started.md
+++ b/docs/en/guide/intro/get-started.md
@@ -26,7 +26,7 @@ Install `@voerkai18n/cli` to global.
 ```shell
 > npm install -g @voerkai18n/cli
 > yarn global add @voerkai18n/cli
-> pnpm add -g @voerkai18/cli
+> pnpm add -g @voerkai18n/cli
 ```
 
 ## Step 2: Initialize the project

--- a/docs/zh/guide/intro/get-started.md
+++ b/docs/zh/guide/intro/get-started.md
@@ -26,7 +26,7 @@ console.log(t("中华人民共和国成立于{}",1949))
 ```shell
 > npm install -g @voerkai18n/cli
 > yarn global add @voerkai18n/cli
-> pnpm add -g @voerkai18/cli
+> pnpm add -g @voerkai18n/cli
 ```
 
 ## 第二步：初始化工程


### PR DESCRIPTION
文档（中英文）中"快速入门"文章的"第一步：安装命令行工具"的pnpm 安装命令单词错误