### PR TITLE
fix: translate result empty judgment error

### DIFF
--- a/packages/runtime/src/translate.ts
+++ b/packages/runtime/src/translate.ts
@@ -88,7 +88,7 @@ export function translate(this:VoerkaI18nScope,message:string,...args:any[]):str
         }else{
             const msgId = scope.idMap[message]  
             // 语言包可能是使用idMap映射过的，则需要转换
-            result = (msgId ? (scope.current as any)[msgId]  : (scope.current as any)[message]) || message
+            result = (msgId ? (scope.current as any)[msgId]  : (scope.current as any)[message]) ?? message
         }
 
          // 2. 处理复数


### PR DESCRIPTION
translate函数在翻译的时候某些传入为""的字段非空判断有误，翻译结果变成了传入的message。比如，t("个"), 英文的情况下对应词条就为"", 但是翻译结果变成了"个"。
示例：https://codesandbox.io/p/devbox/voerkai18n-ci-tiao-fei-kong-pan-duan-wen-ti-zr8g8l?file=%2Fsrc%2Flanguages%2Ftranslates%2Fdefault.json%3A9%2C18